### PR TITLE
feat: changing-room locker management — daily idle-locker email + reception dashboard groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2026-06-24 - LockerMailer
+Added a daily **Idle Locker Report**: at a configured time (default 09:00) it emails a table of assigned changing-room lockers (`Change Room Gents` / `Change Room Ladies`) not opened in more than `IdleDays` (default 14) to a dedicated recipient list. New `IdleLockerReportService` + `LockerMailer:IdleLockerReport` config section. Reuses the existing Dashboards data source and SMTP sender; does not release lockers.
+
 ## 2024-09-26 - AccessController
 Upgraded to new version of a access controller, `src\Shared\AccessController\access_notification_service.proto` changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2026-06-24 - AeosDashboards
+Added "Change Room Gents" and "Change Room Ladies" locker groups to the Locker Management dashboard (default grid view; unlock + unassign enabled) so reception can manage changing-room lockers, using the same flow as the courier/food groups.
+
 ## 2026-06-24 - LockerMailer
 Added a daily **Idle Locker Report**: at a configured time (default 09:00) it emails a table of assigned changing-room lockers (`Change Room Gents` / `Change Room Ladies`) not opened in more than `IdleDays` (default 14) to a dedicated recipient list. New `IdleLockerReportService` + `LockerMailer:IdleLockerReport` config section. Reuses the existing Dashboards data source and SMTP sender; does not release lockers.
 

--- a/src/AEOS/Dashboards/appsettings.json
+++ b/src/AEOS/Dashboards/appsettings.json
@@ -84,6 +84,16 @@
                     "row": "F-301, F-302, F-303, F-304, F-305, <spacer>, <spacer>, F-306, F-307, F-308, F-309"
                   }
                 ]
+              },
+              {
+                "groupName": "Change Room Gents",
+                "allowUnlock": true,
+                "allowUnlockWhenUnassigned": true
+              },
+              {
+                "groupName": "Change Room Ladies",
+                "allowUnlock": true,
+                "allowUnlockWhenUnassigned": true
               }
             
             

--- a/src/AEOS/LockerMailer/Program.cs
+++ b/src/AEOS/LockerMailer/Program.cs
@@ -74,6 +74,7 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer
             services.AddHostedService<MainHostedService>();
             services.AddHostedService<Services.AlarmTriggerService>();
             services.AddHostedService<Services.LockerPickupService>();
+            services.AddHostedService<Services.IdleLockerReportService>();
 
             return services;
         }

--- a/src/AEOS/LockerMailer/README.md
+++ b/src/AEOS/LockerMailer/README.md
@@ -16,17 +16,17 @@ To run the application locally, follow these steps
 ### Deploy to Docker
 - navigate to the root of this repo
 - run the following commands
- - `docker build -f src/AEOS/LockerMailer/Dockerfile -t registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4 .`
- - `docker tag registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4 registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest`
- - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4`
+ - `docker build -f src/AEOS/LockerMailer/Dockerfile -t registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5 .`
+ - `docker tag registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5 registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest`
+ - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5`
  - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest`
 
 ### Deploy to Docker on Arm
 - navigate to the root of this repo
 - run the following commands
- - `docker build -f src/AEOS/LockerMailer/arm.Dockerfile -t registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4-arm .`
- - `docker tag registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4-arm registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest-arm`
- - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.4-arm`
+ - `docker build -f src/AEOS/LockerMailer/arm.Dockerfile -t registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5-arm .`
+ - `docker tag registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5-arm registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest-arm`
+ - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:1.5-arm`
  - `docker push registry.gitlab.com/innovatrics/smartface/integrations-aeoslockermailer:latest-arm`
 
 ## Usage

--- a/src/AEOS/LockerMailer/README.md
+++ b/src/AEOS/LockerMailer/README.md
@@ -145,6 +145,37 @@ The application configuration is stored in `appsettings.json`:
 }
 ```
 
+### Idle Locker Report (daily unused-locker email)
+
+In addition to the alarm-driven flows above, the service sends a **once-per-day report** of
+assigned lockers that have not been opened for a while — e.g. so reception can reclaim unused
+changing-room lockers. It reuses the Dashboards data source and the SMTP sender and does **not**
+release any lockers.
+
+Configured under `LockerMailer:IdleLockerReport`:
+
+```json
+"IdleLockerReport": {
+    "Enabled": true,
+    "TriggerTime": "09:00",
+    "IdleDays": 14,
+    "CheckGroups": ["Change Room Gents", "Change Room Ladies"],
+    "Recipients": ["reception@biometricshouse.com", "peter.novak@innovatrics.com"]
+}
+```
+
+| Key | Meaning |
+|---|---|
+| `Enabled` | Master switch. When `false` the report service does nothing. |
+| `TriggerTime` | Local time of day (`HH:mm`) the report is sent, once per day. |
+| `IdleDays` | Lockers idle for strictly more than this many days are reported. |
+| `CheckGroups` | Locker group names to inspect. |
+| `Recipients` | Email addresses the report is sent to. |
+
+Only **assigned** lockers are reported. Each row shows the locker name, the assignee, and how long
+since it was last opened (e.g. "2 months 3 days ago"). If no lockers qualify, no email is sent.
+Honors the global `LockerMailer:DebugMode` (logs the HTML instead of sending).
+
 ### Configuration Options
 
   sf-station:

--- a/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
+++ b/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
@@ -41,6 +41,11 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
         // Guards against sending more than once on the same day.
         private DateTime? lastSentDate;
 
+        // After TriggerTime, keep retrying a failed run for up to this many minutes before
+        // giving up for the day. Bounds retries so a long outage can't spin forever, while a
+        // brief Dashboards/SMTP blip no longer silently drops the day's report.
+        private const double RetryWindowMinutes = 60;
+
         public IdleLockerReportService(
             ILogger logger,
             IConfiguration configuration,
@@ -108,14 +113,22 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                 try
                 {
                     var now = DateTime.Now;
-                    var withinWindow = Math.Abs((now.TimeOfDay - triggerTime).TotalMinutes) <= 1.0;
+                    // Fire only at or after the configured time (never early), and keep retrying
+                    // within the retry window until a run actually succeeds.
+                    var minutesSinceTrigger = (now.TimeOfDay - triggerTime).TotalMinutes;
+                    var withinWindow = minutesSinceTrigger >= 0 && minutesSinceTrigger <= RetryWindowMinutes;
                     var alreadySentToday = lastSentDate.HasValue && lastSentDate.Value.Date == now.Date;
 
                     if (withinWindow && !alreadySentToday)
                     {
-                        logger.Information($"[IdleLockerReportService] Trigger time reached ({now:HH:mm}) - building idle locker report");
-                        await BuildAndSendReport();
-                        lastSentDate = now;
+                        logger.Information($"[IdleLockerReportService] Running idle locker report ({now:HH:mm})");
+                        // Only mark the day done when the run completed (report sent, or genuinely
+                        // nothing to report after a successful fetch). On a transient failure
+                        // lastSentDate stays unset so the next loop retries within the window.
+                        if (await BuildAndSendReport())
+                        {
+                            lastSentDate = now;
+                        }
                     }
 
                     await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
@@ -135,14 +148,19 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
             }
         }
 
-        private async Task BuildAndSendReport()
+        /// <summary>
+        /// Builds and sends the report. Returns true when the day is "done" — report sent, or
+        /// genuinely nothing to report after a successful fetch. Returns false on a transient
+        /// failure (no groups fetched, or every send failed) so the caller retries within the window.
+        /// </summary>
+        private async Task<bool> BuildAndSendReport()
         {
             // 1. Pull all groups (with per-locker last-used data) from the Dashboards API.
             var groups = await dashboardsDataAdapter.GetGroups();
             if (!groups.Any())
             {
-                logger.Warning("[IdleLockerReportService] No groups returned from Dashboards API - skipping report");
-                return;
+                logger.Warning("[IdleLockerReportService] No groups returned from Dashboards API - will retry");
+                return false;
             }
 
             // 2. Collect assigned lockers in the configured groups that are idle beyond the threshold.
@@ -158,7 +176,10 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
 
                 var matches = group.AllLockers
                     .Where(l => l.AssignedTo.HasValue && !string.IsNullOrWhiteSpace(l.AssignedEmployeeName))
-                    .Where(l => l.DaysSinceLastUse > idleDays)
+                    // Idle beyond the threshold, OR assigned but never opened: upstream maps a
+                    // never-used locker to LastUsed=null with DaysSinceLastUse=0, which would
+                    // otherwise slip past the threshold even though it is the most idle case.
+                    .Where(l => l.LastUsed == null || l.DaysSinceLastUse > idleDays)
                     .Select(l => new IdleLockerRow
                     {
                         LockerName = l.Name,
@@ -172,8 +193,8 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
 
             if (!idleLockers.Any())
             {
-                logger.Information($"[IdleLockerReportService] No assigned lockers idle for more than {idleDays} days in [{string.Join(", ", checkGroups)}] - no email sent");
-                return;
+                logger.Information($"[IdleLockerReportService] No assigned lockers idle beyond {idleDays} days in [{string.Join(", ", checkGroups)}] - nothing to send");
+                return true;
             }
 
             // Most idle first - the most actionable rows are at the top.
@@ -190,10 +211,12 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
             if (debugMode)
             {
                 logger.Information("[IdleLockerReportService] DebugMode enabled - email not sent. Generated HTML:\n" + htmlBody);
-                return;
+                return true;
             }
 
-            // 4. Send to each configured recipient.
+            // 4. Send to each configured recipient. Track successes so that a total failure
+            //    (e.g. SMTP down) reports back as "not done" and the caller retries.
+            var sentCount = 0;
             foreach (var recipient in recipients)
             {
                 if (string.IsNullOrWhiteSpace(recipient))
@@ -217,6 +240,7 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                     };
 
                     await smtpMailAdapter.SendAsync(recipient, subject, htmlBody, loggingData);
+                    sentCount++;
                     logger.Information($"[IdleLockerReportService] Idle locker report sent to {recipient} ({idleLockers.Count} locker(s))");
                 }
                 catch (Exception ex)
@@ -224,6 +248,14 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                     logger.Error(ex, $"[IdleLockerReportService] Failed to send idle locker report to {recipient}");
                 }
             }
+
+            if (sentCount == 0)
+            {
+                logger.Warning("[IdleLockerReportService] Idle locker report reached no recipients - will retry");
+                return false;
+            }
+
+            return true;
         }
 
         private string BuildHtml(List<IdleLockerRow> rows, DateTime today)
@@ -273,22 +305,19 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                 return "Today";
             }
 
-            // Calendar-accurate years / months / days difference.
-            int years = now.Year - last.Year;
-            int months = now.Month - last.Month;
-            int days = now.Day - last.Day;
-
-            if (days < 0)
+            // Calendar-accurate years / months / days difference. Anchor on `last` and add whole
+            // months, then count the leftover days. AddMonths clamps short months (e.g. Jan 30 +
+            // 1 month = Feb 28), which avoids the negative-borrow bug a manual day subtraction hits.
+            int totalMonths = (now.Year - last.Year) * 12 + (now.Month - last.Month);
+            var anchor = last.AddMonths(totalMonths);
+            if (anchor > now)
             {
-                months--;
-                var previousMonth = now.AddMonths(-1);
-                days += DateTime.DaysInMonth(previousMonth.Year, previousMonth.Month);
+                totalMonths--;
+                anchor = last.AddMonths(totalMonths);
             }
-            if (months < 0)
-            {
-                years--;
-                months += 12;
-            }
+            int years = totalMonths / 12;
+            int months = totalMonths % 12;
+            int days = (now.Date - anchor.Date).Days;
 
             var parts = new List<string>();
             if (years > 0) parts.Add($"{years} year{(years == 1 ? "" : "s")}");

--- a/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
+++ b/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Innovatrics.SmartFace.Integrations.LockerMailer.DataModels;
+
+namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
+{
+    /// <summary>
+    /// Background service that, once per day at a configured time, emails a report of the
+    /// assigned lockers in the configured "changing room" groups that have not been opened
+    /// for longer than a configured number of days. The report is sent to a dedicated
+    /// recipient list (e.g. reception) and does NOT release any lockers.
+    ///
+    /// Configuration section: <c>LockerMailer:IdleLockerReport</c>
+    ///   Enabled      - bool, master switch (default false)
+    ///   TriggerTime  - "HH:mm" local time the report is sent (default 09:00)
+    ///   IdleDays     - lockers idle for strictly more than this many days are reported (default 14)
+    ///   CheckGroups  - locker group names to inspect (e.g. "Change Room Gents", "Change Room Ladies")
+    ///   Recipients   - email addresses the report is sent to
+    /// </summary>
+    public class IdleLockerReportService : BackgroundService
+    {
+        private readonly ILogger logger;
+        private readonly IConfiguration configuration;
+        private readonly IDashboardsDataAdapter dashboardsDataAdapter;
+        private readonly ISmtpMailAdapter smtpMailAdapter;
+
+        private readonly bool isEnabled;
+        private readonly TimeSpan triggerTime;
+        private readonly int idleDays;
+        private readonly List<string> checkGroups;
+        private readonly List<string> recipients;
+
+        // Guards against sending more than once on the same day.
+        private DateTime? lastSentDate;
+
+        public IdleLockerReportService(
+            ILogger logger,
+            IConfiguration configuration,
+            IDashboardsDataAdapter dashboardsDataAdapter,
+            ISmtpMailAdapter smtpMailAdapter
+        )
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            this.dashboardsDataAdapter = dashboardsDataAdapter ?? throw new ArgumentNullException(nameof(dashboardsDataAdapter));
+            this.smtpMailAdapter = smtpMailAdapter ?? throw new ArgumentNullException(nameof(smtpMailAdapter));
+
+            var section = configuration.GetSection("LockerMailer:IdleLockerReport");
+
+            isEnabled = section.GetValue<bool>("Enabled", false);
+            idleDays = section.GetValue<int>("IdleDays", 14);
+
+            var triggerTimeRaw = section.GetValue<string>("TriggerTime") ?? "09:00";
+            if (TimeSpan.TryParse(triggerTimeRaw, CultureInfo.InvariantCulture, out var parsedTime))
+            {
+                triggerTime = parsedTime;
+            }
+            else
+            {
+                triggerTime = new TimeSpan(9, 0, 0);
+                logger.Warning($"[IdleLockerReportService] Invalid TriggerTime '{triggerTimeRaw}' - defaulting to 09:00");
+            }
+
+            checkGroups = section.GetSection("CheckGroups").Get<List<string>>() ?? new List<string>();
+            recipients = section.GetSection("Recipients").Get<List<string>>() ?? new List<string>();
+
+            if (!isEnabled)
+            {
+                logger.Information("[IdleLockerReportService] Disabled (LockerMailer:IdleLockerReport:Enabled=false)");
+            }
+            else
+            {
+                logger.Information($"[IdleLockerReportService] Enabled - TriggerTime: {triggerTime:hh\\:mm}, IdleDays: {idleDays}, CheckGroups: [{string.Join(", ", checkGroups)}], Recipients: {recipients.Count}");
+            }
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            if (!isEnabled)
+            {
+                return;
+            }
+
+            if (!checkGroups.Any())
+            {
+                logger.Warning("[IdleLockerReportService] No CheckGroups configured - service will not run");
+                return;
+            }
+
+            if (!recipients.Any())
+            {
+                logger.Warning("[IdleLockerReportService] No Recipients configured - service will not run");
+                return;
+            }
+
+            logger.Information("[IdleLockerReportService] Started");
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var now = DateTime.Now;
+                    var withinWindow = Math.Abs((now.TimeOfDay - triggerTime).TotalMinutes) <= 1.0;
+                    var alreadySentToday = lastSentDate.HasValue && lastSentDate.Value.Date == now.Date;
+
+                    if (withinWindow && !alreadySentToday)
+                    {
+                        logger.Information($"[IdleLockerReportService] Trigger time reached ({now:HH:mm}) - building idle locker report");
+                        await BuildAndSendReport();
+                        lastSentDate = now;
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    logger.Information("[IdleLockerReportService] Service is shutting down");
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "[IdleLockerReportService] Error in idle locker report loop");
+                    // Back off briefly so a persistent failure does not hot-loop.
+                    try { await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken); }
+                    catch (OperationCanceledException) { break; }
+                }
+            }
+        }
+
+        private async Task BuildAndSendReport()
+        {
+            // 1. Pull all groups (with per-locker last-used data) from the Dashboards API.
+            var groups = await dashboardsDataAdapter.GetGroups();
+            if (!groups.Any())
+            {
+                logger.Warning("[IdleLockerReportService] No groups returned from Dashboards API - skipping report");
+                return;
+            }
+
+            // 2. Collect assigned lockers in the configured groups that are idle beyond the threshold.
+            var idleLockers = new List<IdleLockerRow>();
+            foreach (var groupName in checkGroups)
+            {
+                var group = groups.FirstOrDefault(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
+                if (group == null)
+                {
+                    logger.Warning($"[IdleLockerReportService] Configured group '{groupName}' not found in Dashboards response");
+                    continue;
+                }
+
+                var matches = group.AllLockers
+                    .Where(l => l.AssignedTo.HasValue && !string.IsNullOrWhiteSpace(l.AssignedEmployeeName))
+                    .Where(l => l.DaysSinceLastUse > idleDays)
+                    .Select(l => new IdleLockerRow
+                    {
+                        LockerName = l.Name,
+                        AssignedTo = l.AssignedEmployeeName,
+                        LastUsed = l.LastUsed,
+                        DaysSinceLastUse = l.DaysSinceLastUse
+                    });
+
+                idleLockers.AddRange(matches);
+            }
+
+            if (!idleLockers.Any())
+            {
+                logger.Information($"[IdleLockerReportService] No assigned lockers idle for more than {idleDays} days in [{string.Join(", ", checkGroups)}] - no email sent");
+                return;
+            }
+
+            // Most idle first - the most actionable rows are at the top.
+            idleLockers = idleLockers.OrderByDescending(r => r.DaysSinceLastUse).ToList();
+            logger.Information($"[IdleLockerReportService] Found {idleLockers.Count} idle locker(s) - composing email");
+
+            // 3. Build the email.
+            var today = DateTime.Now;
+            var plural = idleLockers.Count == 1 ? "" : "s";
+            var subject = $"Idle changing-room lockers — {today:d MMM yyyy} ({idleLockers.Count} locker{plural})";
+            var htmlBody = BuildHtml(idleLockers, today);
+
+            var debugMode = configuration.GetValue<bool>("LockerMailer:DebugMode", false);
+            if (debugMode)
+            {
+                logger.Information("[IdleLockerReportService] DebugMode enabled - email not sent. Generated HTML:\n" + htmlBody);
+                return;
+            }
+
+            // 4. Send to each configured recipient.
+            foreach (var recipient in recipients)
+            {
+                if (string.IsNullOrWhiteSpace(recipient))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var loggingData = new MailLoggingData
+                    {
+                        TemplateUsed = "idle-locker-report",
+                        EmployeeName = "Idle Locker Report",
+                        EmployeeId = null,
+                        VariableDump = new Dictionary<string, string?>
+                        {
+                            { "idleDays", idleDays.ToString() },
+                            { "lockerCount", idleLockers.Count.ToString() },
+                            { "groups", string.Join(", ", checkGroups) }
+                        }
+                    };
+
+                    await smtpMailAdapter.SendAsync(recipient, subject, htmlBody, loggingData);
+                    logger.Information($"[IdleLockerReportService] Idle locker report sent to {recipient} ({idleLockers.Count} locker(s))");
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"[IdleLockerReportService] Failed to send idle locker report to {recipient}");
+                }
+            }
+        }
+
+        private string BuildHtml(List<IdleLockerRow> rows, DateTime today)
+        {
+            const string cell = "padding:6px 12px;border:1px solid #ddd;";
+            var sb = new StringBuilder();
+
+            sb.Append("<!DOCTYPE html><html><body style=\"font-family:Arial,Helvetica,sans-serif;color:#222;\">");
+            sb.Append($"<p>The following assigned changing-room lockers have not been opened in more than {idleDays} days (as of {today:d MMM yyyy}):</p>");
+            sb.Append("<table style=\"border-collapse:collapse;\">");
+            sb.Append("<thead><tr style=\"background:#f0f0f0;text-align:left;\">");
+            sb.Append($"<th style=\"{cell}\">Locker</th>");
+            sb.Append($"<th style=\"{cell}\">Assigned to</th>");
+            sb.Append($"<th style=\"{cell}\">Last used</th>");
+            sb.Append("</tr></thead><tbody>");
+
+            foreach (var row in rows)
+            {
+                sb.Append("<tr>");
+                sb.Append($"<td style=\"{cell}\">{Escape(row.LockerName)}</td>");
+                sb.Append($"<td style=\"{cell}\">{Escape(row.AssignedTo)}</td>");
+                sb.Append($"<td style=\"{cell}\">{Escape(FormatLastUsed(row.LastUsed, today))}</td>");
+                sb.Append("</tr>");
+            }
+
+            sb.Append("</tbody></table>");
+            sb.Append($"<p style=\"color:#888;font-size:12px;\">Automated report — {rows.Count} locker(s) across {Escape(string.Join(", ", checkGroups))}.</p>");
+            sb.Append("</body></html>");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Renders the elapsed time since <paramref name="lastUsed"/> as a human-friendly,
+        /// calendar-accurate diff such as "2 months 3 days ago (21 Apr 2026)".
+        /// </summary>
+        private static string FormatLastUsed(DateTime? lastUsed, DateTime now)
+        {
+            if (!lastUsed.HasValue)
+            {
+                return "Never used";
+            }
+
+            var last = lastUsed.Value;
+            if (last >= now)
+            {
+                return "Today";
+            }
+
+            // Calendar-accurate years / months / days difference.
+            int years = now.Year - last.Year;
+            int months = now.Month - last.Month;
+            int days = now.Day - last.Day;
+
+            if (days < 0)
+            {
+                months--;
+                var previousMonth = now.AddMonths(-1);
+                days += DateTime.DaysInMonth(previousMonth.Year, previousMonth.Month);
+            }
+            if (months < 0)
+            {
+                years--;
+                months += 12;
+            }
+
+            var parts = new List<string>();
+            if (years > 0) parts.Add($"{years} year{(years == 1 ? "" : "s")}");
+            if (months > 0) parts.Add($"{months} month{(months == 1 ? "" : "s")}");
+            if (days > 0) parts.Add($"{days} day{(days == 1 ? "" : "s")}");
+            if (parts.Count == 0) parts.Add("less than a day");
+
+            return $"{string.Join(" ", parts)} ago ({last:d MMM yyyy})";
+        }
+
+        private static string Escape(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            return value
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;");
+        }
+
+        private sealed class IdleLockerRow
+        {
+            public string LockerName { get; set; } = string.Empty;
+            public string AssignedTo { get; set; } = string.Empty;
+            public DateTime? LastUsed { get; set; }
+            public double DaysSinceLastUse { get; set; }
+        }
+    }
+}

--- a/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
+++ b/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
@@ -165,6 +165,7 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
 
             // 2. Collect assigned lockers in the configured groups that are idle beyond the threshold.
             var idleLockers = new List<IdleLockerRow>();
+            var matchedGroups = 0;
             foreach (var groupName in checkGroups)
             {
                 var group = groups.FirstOrDefault(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
@@ -174,12 +175,15 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                     continue;
                 }
 
+                matchedGroups++;
+
                 var matches = group.AllLockers
                     .Where(l => l.AssignedTo.HasValue && !string.IsNullOrWhiteSpace(l.AssignedEmployeeName))
-                    // Idle beyond the threshold, OR assigned but never opened: upstream maps a
-                    // never-used locker to LastUsed=null with DaysSinceLastUse=0, which would
-                    // otherwise slip past the threshold even though it is the most idle case.
-                    .Where(l => l.LastUsed == null || l.DaysSinceLastUse > idleDays)
+                    // Strictly more than the idle threshold. Never-opened lockers (LastUsed null,
+                    // DaysSinceLastUse 0 upstream) are intentionally NOT reported: with no assignment
+                    // timestamp we cannot tell a freshly-assigned locker from a long-idle one, so
+                    // flagging every just-assigned locker would be a daily false positive.
+                    .Where(l => l.DaysSinceLastUse > idleDays)
                     .Select(l => new IdleLockerRow
                     {
                         LockerName = l.Name,
@@ -189,6 +193,12 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                     });
 
                 idleLockers.AddRange(matches);
+            }
+
+            if (matchedGroups == 0)
+            {
+                logger.Warning($"[IdleLockerReportService] None of the configured groups [{string.Join(", ", checkGroups)}] were present in the Dashboards response - will retry");
+                return false;
             }
 
             if (!idleLockers.Any())

--- a/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
+++ b/src/AEOS/LockerMailer/Services/IdleLockerReportService.cs
@@ -114,7 +114,9 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
                 {
                     var now = DateTime.Now;
                     // Fire only at or after the configured time (never early), and keep retrying
-                    // within the retry window until a run actually succeeds.
+                    // within the retry window until a run actually succeeds. The window is same-day
+                    // only, so TriggerTime should be earlier than (24:00 minus RetryWindowMinutes);
+                    // the 09:00 default is well clear of midnight.
                     var minutesSinceTrigger = (now.TimeOfDay - triggerTime).TotalMinutes;
                     var withinWindow = minutesSinceTrigger >= 0 && minutesSinceTrigger <= RetryWindowMinutes;
                     var alreadySentToday = lastSentDate.HasValue && lastSentDate.Value.Date == now.Date;
@@ -177,7 +179,9 @@ namespace Innovatrics.SmartFace.Integrations.LockerMailer.Services
 
                 matchedGroups++;
 
-                var matches = group.AllLockers
+                // AllLockers can be null if the API returns "allLockers": null (other services in
+                // this repo access it defensively too) - treat a null list as an empty group.
+                var matches = (group.AllLockers ?? new List<LockerInfo>())
                     .Where(l => l.AssignedTo.HasValue && !string.IsNullOrWhiteSpace(l.AssignedEmployeeName))
                     // Strictly more than the idle threshold. Never-opened lockers (LastUsed null,
                     // DaysSinceLastUse 0 upstream) are intentionally NOT reported: with no assignment

--- a/src/AEOS/LockerMailer/appsettings.json
+++ b/src/AEOS/LockerMailer/appsettings.json
@@ -64,6 +64,19 @@
       "ReceptionistEmails": [
         "a@a.com"
       ],
+      "IdleLockerReport": {
+        "Enabled": true,
+        "TriggerTime": "09:00",
+        "IdleDays": 14,
+        "CheckGroups": [
+          "Change Room Gents",
+          "Change Room Ladies"
+        ],
+        "Recipients": [
+          "reception@biometricshouse.com",
+          "peter.novak@innovatrics.com"
+        ]
+      },
       "Templates": [
         {
           "templateName": "Food Delivery",

--- a/src/AEOS/LockerMailer/appsettings.json
+++ b/src/AEOS/LockerMailer/appsettings.json
@@ -73,8 +73,8 @@
           "Change Room Ladies"
         ],
         "Recipients": [
-          "reception@biometricshouse.com",
-          "peter.novak@innovatrics.com"
+          "b@b.com",
+          "c@c.com"
         ]
       },
       "Templates": [


### PR DESCRIPTION
DESCRIPTION (markdown)
----------------------
## Summary

Two related changes that help keep changing-room (and courier/food) lockers tidy:

1. **LockerMailer** — a new daily email reporting changing-room lockers nobody has opened in a while.
2. **AeosDashboards** — the receptionists' Locker Management screen now also covers the changing-room locker groups, so reception can unassign/unlock them.

Both reuse the existing AEOS "Dashboards" data source and the existing send/UI flows — no new infrastructure.

---

## 1. Daily idle-locker report (LockerMailer)

New `IdleLockerReportService` (hosted service): once per day at **09:00** it pulls locker groups from the Dashboards API, selects **assigned** lockers in **Change Room Gents / Change Room Ladies** not opened in **more than 14 days**, and emails an HTML table (Locker · Assigned to · Last used) to a dedicated recipient list. Does **not** release lockers; skips sending when nothing qualifies; honors `DebugMode`.

New config section `LockerMailer:IdleLockerReport`:

```json
"IdleLockerReport": {
  "Enabled": true,
  "TriggerTime": "09:00",
  "IdleDays": 14,
  "CheckGroups": ["Change Room Gents", "Change Room Ladies"],
  "Recipients": ["reception@biometricshouse.com", "peter.novak@innovatrics.com"]
}
```

"Last used" renders as a human diff, e.g. `2 months 3 days ago (21 Apr 2026)`.

## 2. Changing-room groups on the Locker Management dashboard (AeosDashboards)

Added **Change Room Gents** and **Change Room Ladies** to `AeosDashboards:LockerManagement:GroupConfiguration`, so two new group buttons appear on the Locker Management screen alongside Courier Items / Courier Food. Receptionists can **Unassign** and **Unlock** changing-room lockers through the same modal flow. Default grid view (no custom wall layout); `allowUnlock` + `allowUnlockWhenUnassigned` enabled. Config-only — no code changes.

---

## Notes for review

- **Not compiled locally** (no .NET SDK on the dev box) — relying on CI for the build.
- The idle-report trigger uses the **host's local time** (consistent with the existing LockerMailer alarms) — set the container TZ accordingly.
- The dashboard modal also shows **Assign** for empty changing-room lockers (same shared flow as courier/food). If reception should only unassign/unlock these groups, that's a small follow-up (per-group flag to hide Assign).
- Group names must match AEOS exactly; `Change Room Gents` / `Change Room Ladies` match the names already used in the LockerMailer config.
- The dashboard groups ship via the committed `appsettings.json` baked into the `aeosdashboards` image.

## Commits

- `feat(LockerMailer): daily idle changing-room locker report`
- `feat(AeosDashboards): add changing-room locker groups to Locker Management`
